### PR TITLE
(FSE-742) chore: fetch vesting information from REST RPC

### DIFF
--- a/api/handler/v1/helpersTransaction.go
+++ b/api/handler/v1/helpersTransaction.go
@@ -25,7 +25,11 @@ type BaseAccount struct {
 }
 
 type BaseVestingAccount struct {
-	BaseAccount BaseAccount `json:"base_account"`
+	BaseAccount      BaseAccount      `json:"base_account"`
+	OriginalVesting  []BalanceElement `json:"original_vesting"`
+	DelegatedFree    []BalanceElement `json:"delegated_free"`
+	DelegatedVesting []BalanceElement `json:"delegated_vesting"`
+	EndTime          string           `json:"end_time"`
 }
 type BaseAccountDetails struct {
 	Type               string             `json:"@type"`

--- a/api/handler/v2/vesting.go
+++ b/api/handler/v2/vesting.go
@@ -89,7 +89,6 @@ func (h *Handler) VestingByAddress(ctx *fasthttp.RequestCtx) {
 	}
 
 	res, err := restClient.GetVestingAccount(address)
-
 	if err != nil {
 		ctx.Logger().Printf("Error getting vesting account: %s", err.Error())
 		sendInternalErrorResponse(ctx)

--- a/api/handler/v2/vesting.go
+++ b/api/handler/v2/vesting.go
@@ -4,35 +4,9 @@
 package v2
 
 import (
-	"encoding/json"
-
-	"github.com/evmos/evmos/v12/x/vesting/types"
-	v1 "github.com/tharsis/dashboard-backend/api/handler/v1"
 	"github.com/tharsis/dashboard-backend/internal/v2/node/rest"
 	"github.com/valyala/fasthttp"
 )
-
-type VestingAccount struct {
-	Account struct {
-		Type               string                `json:"@type"`
-		BaseVestingAccount v1.BaseVestingAccount `json:"base_vesting_account"`
-		FunderAddress      string                `json:"funder_address"`
-		StartTime          string                `json:"start_time"`
-		LockupPeriods      []struct {
-			Length string              `json:"length"`
-			Amount []v1.BalanceElement `json:"amount"`
-		} `json:"lockup_periods"`
-		VestingPeriods []struct {
-			Length string              `json:"length"`
-			Amount []v1.BalanceElement `json:"amount"`
-		} `json:"vesting_periods"`
-	} `json:"account"`
-}
-
-type VestingByAddressResponse struct {
-	VestingAccount
-	types.QueryBalancesResponse
-}
 
 // VestingByAddress handles GET /v2/vesting/{address}.
 // It returns the vesting information of the requested address.
@@ -114,41 +88,12 @@ func (h *Handler) VestingByAddress(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
-	accountRes, err := restClient.Get("/cosmos/auth/v1beta1/accounts/" + address)
+	res, err := restClient.GetVestingAccount(address)
 
 	if err != nil {
-		ctx.Logger().Printf("Error querying vesting account from RPC: %s", err.Error())
+		ctx.Logger().Printf("Error getting vesting account: %s", err.Error())
 		sendInternalErrorResponse(ctx)
 		return
-	}
-
-	var account VestingAccount
-	err = json.Unmarshal(accountRes, &account)
-	if err != nil {
-		ctx.Logger().Printf("Error decoding vesting account: %s", err.Error())
-		sendInternalErrorResponse(ctx)
-		return
-	}
-
-	rewardsRes, err := restClient.Get("/evmos/vesting/v1/balances/" + address)
-
-	if err != nil {
-		ctx.Logger().Printf("Error querying vesting balance from RPC: %s", err.Error())
-		sendInternalErrorResponse(ctx)
-		return
-	}
-
-	var vestingBalance types.QueryBalancesResponse
-	err = json.Unmarshal(rewardsRes, &vestingBalance)
-	if err != nil {
-		ctx.Logger().Printf("Error decoding vesting account: %s", err.Error())
-		sendInternalErrorResponse(ctx)
-		return
-	}
-
-	res := VestingByAddressResponse{
-		VestingAccount:        account,
-		QueryBalancesResponse: vestingBalance,
 	}
 
 	sendSuccessfulJSONResponse(ctx, res)

--- a/internal/v2/node/rest/client.go
+++ b/internal/v2/node/rest/client.go
@@ -49,7 +49,7 @@ func (c *Client) post(endpoint string, body []byte) ([]byte, error) {
 
 // get defines a wrapper around an HTTP GET request with a provided URL.
 // An error is returned if the request or reading the body fails.
-func (c *Client) Get(endpoint string) ([]byte, error) {
+func (c *Client) get(endpoint string) ([]byte, error) {
 	res, err := c.requestWithRetries("GET", endpoint, []byte{})
 	if err != nil {
 		return nil, fmt.Errorf("error while making get request: %w", err)

--- a/internal/v2/node/rest/tx.go
+++ b/internal/v2/node/rest/tx.go
@@ -23,7 +23,7 @@ func (c *Client) BroadcastTx(txBytes []byte) (tx.BroadcastTxResponse, error) {
 	jsonResponse := tx.BroadcastTxResponse{}
 	err = encConfig.Codec.UnmarshalJSON(postResponse, &jsonResponse)
 	if err != nil {
-		return tx.BroadcastTxResponse{}, fmt.Errorf("error while unmarshalling response body: %w", err)
+		return tx.BroadcastTxResponse{}, fmt.Errorf("Error while unmarshalling response body: %w", err)
 	}
 	return jsonResponse, nil
 }

--- a/internal/v2/node/rest/vesting.go
+++ b/internal/v2/node/rest/vesting.go
@@ -31,29 +31,26 @@ type VestingByAddressResponse struct {
 }
 
 func (c *Client) GetVestingAccount(address string) (VestingByAddressResponse, error) {
-	accountRes, err := c.Get("/cosmos/auth/v1beta1/accounts/" + address)
-
+	accountRes, err := c.get("/cosmos/auth/v1beta1/accounts/" + address)
 	if err != nil {
-		return VestingByAddressResponse{}, fmt.Errorf("error querying vesting account from RPC: %s", err.Error())
+		return VestingByAddressResponse{}, fmt.Errorf("Error querying vesting account from RPC: %s", err.Error())
 	}
 
 	var account VestingAccount
-
 	err = json.Unmarshal(accountRes, &account)
 	if err != nil {
-		return VestingByAddressResponse{}, fmt.Errorf("error decoding vesting account: %s", err.Error())
+		return VestingByAddressResponse{}, fmt.Errorf("Error decoding vesting account: %s", err.Error())
 	}
 
-	rewardsRes, err := c.Get("/evmos/vesting/v1/balances/" + address)
-
+	rewardsRes, err := c.get("/evmos/vesting/v1/balances/" + address)
 	if err != nil {
-		return VestingByAddressResponse{}, fmt.Errorf("error querying vesting balance from RPC: %s", err.Error())
+		return VestingByAddressResponse{}, fmt.Errorf("Error querying vesting balance from RPC: %s", err.Error())
 	}
 
 	var vestingBalance types.QueryBalancesResponse
 	err = json.Unmarshal(rewardsRes, &vestingBalance)
 	if err != nil {
-		return VestingByAddressResponse{}, fmt.Errorf("error decoding vesting account: %s", err.Error())
+		return VestingByAddressResponse{}, fmt.Errorf("Error decoding vesting account: %s", err.Error())
 	}
 
 	res := VestingByAddressResponse{

--- a/internal/v2/node/rest/vesting.go
+++ b/internal/v2/node/rest/vesting.go
@@ -1,0 +1,65 @@
+package rest
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/evmos/evmos/v12/x/vesting/types"
+	v1 "github.com/tharsis/dashboard-backend/api/handler/v1"
+)
+
+type VestingAccount struct {
+	Account struct {
+		Type               string                `json:"@type"`
+		BaseVestingAccount v1.BaseVestingAccount `json:"base_vesting_account"`
+		FunderAddress      string                `json:"funder_address"`
+		StartTime          string                `json:"start_time"`
+		LockupPeriods      []struct {
+			Length string              `json:"length"`
+			Amount []v1.BalanceElement `json:"amount"`
+		} `json:"lockup_periods"`
+		VestingPeriods []struct {
+			Length string              `json:"length"`
+			Amount []v1.BalanceElement `json:"amount"`
+		} `json:"vesting_periods"`
+	} `json:"account"`
+}
+
+type VestingByAddressResponse struct {
+	VestingAccount
+	types.QueryBalancesResponse
+}
+
+func (c *Client) GetVestingAccount(address string) (VestingByAddressResponse, error) {
+	accountRes, err := c.Get("/cosmos/auth/v1beta1/accounts/" + address)
+
+	if err != nil {
+		return VestingByAddressResponse{}, fmt.Errorf("error querying vesting account from RPC: %s", err.Error())
+	}
+
+	var account VestingAccount
+
+	err = json.Unmarshal(accountRes, &account)
+	if err != nil {
+		return VestingByAddressResponse{}, fmt.Errorf("error decoding vesting account: %s", err.Error())
+	}
+
+	rewardsRes, err := c.Get("/evmos/vesting/v1/balances/" + address)
+
+	if err != nil {
+		return VestingByAddressResponse{}, fmt.Errorf("error querying vesting balance from RPC: %s", err.Error())
+	}
+
+	var vestingBalance types.QueryBalancesResponse
+	err = json.Unmarshal(rewardsRes, &vestingBalance)
+	if err != nil {
+		return VestingByAddressResponse{}, fmt.Errorf("error decoding vesting account: %s", err.Error())
+	}
+
+	res := VestingByAddressResponse{
+		VestingAccount:        account,
+		QueryBalancesResponse: vestingBalance,
+	}
+
+	return res, nil
+}


### PR DESCRIPTION
This PR changes the Vesting endpoint to query the EVMOS REST RPC instead of Numia to get vesting information

https://linear.app/altiplanic/issue/FSE-742/migrate-backend-out-of-numia
