### PR TITLE
feat: adds neok support

### DIFF
--- a/api/handler/v1/balances.go
+++ b/api/handler/v1/balances.go
@@ -23,7 +23,7 @@ type BalanceResponse struct {
 
 func BalanceByNetworkAndDenom(ctx *fasthttp.RequestCtx) {
 	token := paramToString("token", ctx)
-	denom := ""
+	denom := token
 
 	coinConfigs, err := resources.GetERC20Tokens()
 	if err != nil {

--- a/api/handler/v1/helpersTransaction.go
+++ b/api/handler/v1/helpersTransaction.go
@@ -164,6 +164,9 @@ func GetDenom(token string, srcChain string) (string, error) {
 		}
 		return tokensByName.Values.CosmosDenom, nil
 
+	} else if strings.HasPrefix(token, "ibc/") {
+		// That means that the token is already in the format ibc/{denom}, so it was converted by the requester
+		return token, nil
 	} else {
 		token, err := ERC20TokensByNameInternal(token)
 		if err != nil {

--- a/api/handler/v1/transaction.go
+++ b/api/handler/v1/transaction.go
@@ -204,7 +204,7 @@ const (
 	DefaultGas float64 = 350000
 	// osmosis had an upgrade V15, and it seems they got rid of 0 fees and put in minimum fees
 	// such minimum fees are requiring more gas, from the expected 200000 to 250000
-	DefaultGasIbcTransfer          float64 = 250000
+	DefaultGasIbcTransfer          float64 = 300000
 	feeDenom                       string  = "aevmos"
 	EvmosTxFeeConvertAssetGas      float64 = 10500000
 	DefaultGasIbcTransferUint      uint64  = 200000


### PR DESCRIPTION
Three changes here:

1- BalanceByNetworkAndDenom: fallback to the sent denom so I can pass denoms that are not listed in our registry (in our case, ibc denoms for neok)
2- GetDenom: Same thing here
3- bump the gas price as a quick fix to some tx that requires a little extra gas 