### PR TITLE
chore: replace empty string with 0

### DIFF
--- a/api/handler/v1/erc20.go
+++ b/api/handler/v1/erc20.go
@@ -180,7 +180,7 @@ func ERC20ModuleBalance(ctx *fasthttp.RequestCtx) {
 		// TODO: consider moving this to a work or remove the container mutex
 		val, err := blockchain.GetERC20Balance(v.Erc20, ethAddress)
 		balance := "0"
-		if err == nil {
+		if err == nil && val != "" {
 			balance = val
 		}
 


### PR DESCRIPTION
ERC20ModuleBalance endpoint returns the ERC20 balance of some tokens with and empty string when the RPC fails.

This patches the endpoint to return with 0 in case RPC fails instead of ""