### PR TITLE
Add price change and bundle price calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,9 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## Unreleased
 
+- (chore) [fse-710] Bundle all price cron API calls into a single API call for all tokens
+- (chore) [fse-710] Fetch evmos 24h price change and return it on the ERC20ModuleBalance endpoint
+
 ### Improvements
 
 - (chore) [fse-536] Adding dependabot

--- a/api/handler/v1/erc20.go
+++ b/api/handler/v1/erc20.go
@@ -52,9 +52,10 @@ type ERC20Entry struct {
 		URL            string `json:"url"`
 		HandlingAction string `json:"handlingAction"`
 	} `json:"handledByExternalUI"`
-	ERC20Address string `json:"erc20Address"`
-	PngSrc       string `json:"pngSrc"`
-	Prefix       string `json:"prefix"`
+	ERC20Address   string `json:"erc20Address"`
+	PngSrc         string `json:"pngSrc"`
+	Prefix         string `json:"prefix"`
+	Price24HChange string `json:"price24HChange"`
 }
 
 type ModuleBalanceContainer struct {
@@ -100,6 +101,7 @@ func ERC20ModuleEmptyBalance(ctx *fasthttp.RequestCtx) {
 		networkConfig := networkConfigs[configIdx]
 		mainnetConfig := resources.GetMainnetConfig(networkConfig)
 		coingeckoPrice := GetCoingeckoPrice(v.CoingeckoID)
+		coin24hChnage := GetCoingecko24HChange(v.CoingeckoID)
 		container.values[k] = ERC20Entry{
 			Name:                v.Name,
 			Symbol:              v.Symbol,
@@ -116,6 +118,7 @@ func ERC20ModuleEmptyBalance(ctx *fasthttp.RequestCtx) {
 			ERC20Address:        v.Erc20,
 			PngSrc:              v.PngSrc,
 			Prefix:              v.Prefix,
+			Price24HChange:      coin24hChnage,
 		}
 		index++
 	}
@@ -195,6 +198,7 @@ func ERC20ModuleBalance(ctx *fasthttp.RequestCtx) {
 		networkConfig := networkConfigs[configIdx]
 		mainnetConfig := resources.GetMainnetConfig(networkConfig)
 		coingeckoPrice := GetCoingeckoPrice(v.CoingeckoID)
+		coin24hChnage := GetCoingecko24HChange(v.CoingeckoID)
 
 		container.values[k] = ERC20Entry{
 			Name:                v.Name,
@@ -212,6 +216,7 @@ func ERC20ModuleBalance(ctx *fasthttp.RequestCtx) {
 			ERC20Address:        v.Erc20,
 			PngSrc:              v.PngSrc,
 			Prefix:              v.Prefix,
+			Price24HChange:      coin24hChnage,
 		}
 		index++
 	}

--- a/api/handler/v1/helpers.go
+++ b/api/handler/v1/helpers.go
@@ -74,6 +74,15 @@ func GetCoingeckoPrice(coingeckoID string) string {
 	return price
 }
 
+func GetCoingecko24HChange(coingeckoID string) string {
+	change := "0"
+	val, err := db.RedisGet24HChange(coingeckoID)
+	if err == nil {
+		change = val
+	}
+	return change
+}
+
 func paramToString(param string, ctx *fasthttp.RequestCtx) string {
 	return fmt.Sprint(ctx.UserValue(param))
 }

--- a/cronjobs/redis_functions.py
+++ b/cronjobs/redis_functions.py
@@ -32,6 +32,9 @@ def redisSetPrice(asset: str, vs_currency: str, price: float):
     key = f'{asset}|{vs_currency}|price'
     r.mset({key: price})
 
+def redisSetEvmosChange(change: float):
+    key = f'evmos|24h|change'
+    r.mset({key: change})
 
 def redisGetPrice(asset: str, vs_currency: str) -> float | None:
     key = f'{asset}|{vs_currency}|price'

--- a/internal/v1/db/price.go
+++ b/internal/v1/db/price.go
@@ -22,6 +22,11 @@ func RedisGetPrice(asset string, vsCurrency string) (string, error) {
 	return formatRedisResponse(val, err)
 }
 
+func RedisGet24HChange(asset string) (string, error) {
+	val, err := rdb.Get(ctxRedis, asset+"|24h|change").Result()
+	return formatRedisResponse(val, err)
+}
+
 func RedisSetPrice(asset string, vsCurrency string, price string) {
 	key := buildKeyPrice(asset, vsCurrency)
 	err := rdb.Set(ctxRedis, key, price, 0).Err()


### PR DESCRIPTION
This PR adds the following updates:

- Refactor the python cronjob to fetch all the token prices with one API call instead of having one API call per token

- Add an extra step to the price cron job to fetch the EVMOS token 24hour