### PR TITLE
Load balance eth gas price request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,10 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## Unreleased
 
+## 1.3.5 - 2023-12-12
+
+- (chore) [fse-897] Use loadbalanced post request for eth gas price
+
 ## 1.3.4 - 2023-12-12
 
 - (chore) [fse-897] Replace lava RPC with allnodes RPC for eth gas price

--- a/api/handler/v1/proxy.go
+++ b/api/handler/v1/proxy.go
@@ -4,6 +4,7 @@
 package v1
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"strconv"
@@ -32,8 +33,11 @@ func Epochs(ctx *fasthttp.RequestCtx) {
 }
 
 func EthGasPriceInternal() (string, error) {
-	url := "https://evmos-evm.publicnode.com"
-	val, _ := requester.MakePostGasPrice(url)
+	payload := bytes.NewBuffer([]byte(`{"jsonrpc":"2.0","method":"eth_gasPrice","params":[],"id":1}`))
+	val, err := requester.MakePostRequest("EVMOS", "web3", "/", payload.Bytes())
+	if err != nil {
+		return "", err
+	}
 	return val, nil
 }
 


### PR DESCRIPTION
This PR uses a post request helper function that tries multiple ETH RPCs in order to get eth gas price for broadcasting transactions