### PR TITLE
Fixes convert call

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,7 +30,7 @@ jobs:
       - uses: golangci/golangci-lint-action@v3.4.0
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: 1.54.2
+          version: v1.54.2
           args: --timeout 10m
           github-token: ${{ secrets.github_token }}
         # Check only if there are differences in the source code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,13 +36,15 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## Unreleased
 
+- (fix) [fse-900] Fix failing convertCoin and convertERC20 endpoints
+
 ## 1.3.7 - 2023-12-13
 
 - (chore) [fse-897] Update github actions
 
 ## 1.3.6 - 2023-12-13
 
-- (chore) [fse-897] Fix linter version 
+- (chore) [fse-897] Fix linter version
 
 ## 1.3.5 - 2023-12-12
 


### PR DESCRIPTION
ERC20TokensByNameInternal was checking the denom against the file name, which it didn't match in the case of wormhole tokens

this changes the logic a bit to check by the internal cosmos denom