### PR TITLE
Rename gravity identifier

### DIFF
--- a/cronjobs/constants.py
+++ b/cronjobs/constants.py
@@ -15,7 +15,7 @@ EVMOS = "EVMOS"
 INDEXING_DISABLED_ERROR = "transaction indexing is disabled"
 
 class Networks(Enum):
-    GRAV = 'GRAVITY'
+    GRAV = 'GRAVITYBRIDGE'
     EVMOS = 'EVMOS'
     OSMOSIS = 'OSMOSIS'
     COSMOS = 'COSMOS'

--- a/cronjobs/cron.py
+++ b/cronjobs/cron.py
@@ -127,7 +127,7 @@ def ping_rest(endpoint: str, rest_list: EndpointSafeList, tendermint_exposed=Tru
 
 
 def process_chain(chain: str, chain_info):
-    tendermint_exposed = chain != 'GRAVITY'
+    tendermint_exposed = chain != 'GRAVITYBRIDGE'
     rest_threads = []
     rest_list = EndpointSafeList()
     for rest in chain_info[chain]['rest']:

--- a/cronjobs/scripts/entrypoint.sh
+++ b/cronjobs/scripts/entrypoint.sh
@@ -19,4 +19,5 @@ do
   fi
   sleep 2
 done
-python $1.py
+
+python -u $1.py

--- a/internal/v1/constants/networks.go
+++ b/internal/v1/constants/networks.go
@@ -4,7 +4,7 @@
 package constants
 
 const (
-	GRAV    = "GRAVITY"
+	GRAV    = "GRAVITYBRIDGE"
 	EVMOS   = "EVMOS"
 	OSMOSIS = "OSMOSIS"
 	COSMOS  = "COSMOS"


### PR DESCRIPTION
gravity identifier is now "gravitybridge" in the registry to match the cosmos registry, so updated it here to match